### PR TITLE
udpate descriptor contracts

### DIFF
--- a/apps/gallery/src/contracts/nounsDescriptor.ts
+++ b/apps/gallery/src/contracts/nounsDescriptor.ts
@@ -1,5 +1,5 @@
 export const nounsDescriptorContractAddress =
-  "0x25fF2FdE7df1A433E09749C952f7e09aD3C27951" as `0x${string}`;
+  "0x33A9c445fb4FB21f2c030A6b2d3e2F12D017BFAC" as `0x${string}`;
 
 export const nounsDescriptorAbi = [
   {

--- a/packages/noggles/src/contracts/nounsDescriptor.ts
+++ b/packages/noggles/src/contracts/nounsDescriptor.ts
@@ -1,5 +1,5 @@
 export const nounsDescriptorContractAddress =
-  "0x25fF2FdE7df1A433E09749C952f7e09aD3C27951" as `0x${string}`;
+  "0x33A9c445fb4FB21f2c030A6b2d3e2F12D017BFAC" as `0x${string}`;
 
 export const nounsDescriptorAbi = [
   {


### PR DESCRIPTION
Prop [617](https://www.nouns.camp/proposals/617?tab=transactions) changed the Descriptor contract, but the noundry props are still pointing to the old one: [640](https://www.nouns.camp/proposals/640?tab=transactions)

This PR is just to update the contract addresses.