### PR TITLE
feat: restore enhanced guidelines page with images from PR #38

### DIFF
--- a/apps/gallery/src/variants/lil-nouns/components/Guidelines.tsx
+++ b/apps/gallery/src/variants/lil-nouns/components/Guidelines.tsx
@@ -77,7 +77,7 @@ export const Guidelines = () => {
             <div className="flex flex-col gap-4">
               <h3 className="text-lg font-semibold">Example: Good Trait Design</h3>
               <p>
-                Here's an example of a well-designed trait that follows all our guidelines:
+                Here&apos;s an example of a well-designed trait that follows all our guidelines:
               </p>
               <img 
                 src="/noundry-guidelines-example.png" 

--- a/apps/gallery/src/variants/nouns/components/Guidelines.tsx
+++ b/apps/gallery/src/variants/nouns/components/Guidelines.tsx
@@ -77,7 +77,7 @@ export const Guidelines = () => {
             <div className="flex flex-col gap-4">
               <h3 className="text-lg font-semibold">Example: Good Trait Design</h3>
               <p>
-                Here's an example of a well-designed trait that follows all our guidelines:
+                Here&apos;s an example of a well-designed trait that follows all our guidelines:
               </p>
               <img 
                 src="/noundry-guidelines-example.png" 


### PR DESCRIPTION
- Add drawing order & layering guidelines section with visual example
- Add head cropping guidelines section with example image  
- Add good trait design example section
- Incorporate all 3 images that were originally added in PR #38
- Apply changes to both Nouns and Lil Nouns variants
- Restore visual enhancements that were lost during Next.js app router migration