### PR TITLE
Fix #57 image import preview by scaling uploaded images to canvas size

### DIFF
--- a/apps/studio/src/components/PartImporter.tsx
+++ b/apps/studio/src/components/PartImporter.tsx
@@ -148,7 +148,7 @@ export const PartImporter: FC<PartImporterProps> = ({
         hasPartLoaded={hasPartLoaded}
         onPartLoaded={(image: HTMLImageElement) => {
           clearCanvas(tmpCanvas);
-          tmpCanvas.getContext("2d")!.drawImage(image, 0, 0);
+          tmpCanvas.getContext("2d")!.drawImage(image, 0, 0, tmpCanvas.width, tmpCanvas.height);
           const substitutionCandidates = getColorSubstitutionCandidates(
             tmpCanvas,
             5

--- a/apps/studio/src/components/PartImporter.tsx
+++ b/apps/studio/src/components/PartImporter.tsx
@@ -148,7 +148,10 @@ export const PartImporter: FC<PartImporterProps> = ({
         hasPartLoaded={hasPartLoaded}
         onPartLoaded={(image: HTMLImageElement) => {
           clearCanvas(tmpCanvas);
-          tmpCanvas.getContext("2d")!.drawImage(image, 0, 0, tmpCanvas.width, tmpCanvas.height);
+          const ctx = tmpCanvas.getContext("2d")!;
+          ctx.imageSmoothingEnabled = false;
+          ctx.drawImage(image, 0, 0, tmpCanvas.width, tmpCanvas.height);
+          
           const substitutionCandidates = getColorSubstitutionCandidates(
             tmpCanvas,
             5


### PR DESCRIPTION
- Updated drawImage call in PartImporter.tsx to scale images to fit canvas dimensions
- This resolves the issue where uploaded images were not visible in the preview grid
- Fixes import functionality for accessory, noggles, head, body, and background parts